### PR TITLE
feat: create before destroy for pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.2.0-rc.0 |
 
 ## Modules
@@ -27,6 +28,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [scaleway_k8s_cluster.this](https://registry.terraform.io/providers/particuleio/scaleway/2.2.0-rc.0/docs/resources/k8s_cluster) | resource |
 | [scaleway_k8s_pool.this](https://registry.terraform.io/providers/particuleio/scaleway/2.2.0-rc.0/docs/resources/k8s_pool) | resource |
 

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
     placement_group_id  = null
     container_runtime   = "containerd"
     tags                = []
-    wait_for_pool_ready = false
+    wait_for_pool_ready = true
     kubelet_args        = null
     zone                = null
     upgrade_policy = {

--- a/node-pools.tf
+++ b/node-pools.tf
@@ -3,7 +3,7 @@ resource "scaleway_k8s_pool" "this" {
   region             = var.region
   zone               = lookup(each.value, "zone", local.node_pools_defaults["zone"])
   cluster_id         = scaleway_k8s_cluster.this.id
-  name               = each.key
+  name               = "${each.key}-${random_pet.this[each.key].id}"
   node_type          = lookup(each.value, "node_type", local.node_pools_defaults["node_type"])
   size               = lookup(each.value, "size", local.node_pools_defaults["size"])
   min_size           = lookup(each.value, "min_size", local.node_pools_defaults["min_size"])
@@ -21,8 +21,16 @@ resource "scaleway_k8s_pool" "this" {
   tags                = distinct(compact(concat(lookup(each.value, "tags", local.node_pools_defaults["tags"]), var.tags)))
 
   lifecycle {
-    ignore_changes = [
-      size
-    ]
+    create_before_destroy = true
+  }
+}
+
+resource "random_pet" "this" {
+  for_each = local.node_pools
+  keepers = {
+    placement_group_id = lookup(each.value, "placement_group_id", "")
+    zone               = lookup(each.value, "zone", "")
+    container_runtime  = lookup(each.value, "container_runtime", "")
+    node_type          = lookup(each.value, "node_type", "")
   }
 }


### PR DESCRIPTION
BREAKING CHANGE : use random pet to be able to create before destroy
node pool

* Also use wait for pool as default

Signed-off-by: Kevin Lefevre <kevin@particule.io>