### PR TITLE
chore: upgrade scaleway provider to 2.2.0 (previsouly particuleio/scaleway@2.2.0-rc.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | 2.2.0-rc.0 |
+| <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | 2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.2.0-rc.0 |
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | 2.2.0 |
 
 ## Modules
 
@@ -29,8 +29,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
-| [scaleway_k8s_cluster.this](https://registry.terraform.io/providers/particuleio/scaleway/2.2.0-rc.0/docs/resources/k8s_cluster) | resource |
-| [scaleway_k8s_pool.this](https://registry.terraform.io/providers/particuleio/scaleway/2.2.0-rc.0/docs/resources/k8s_pool) | resource |
+| [scaleway_k8s_cluster.this](https://registry.terraform.io/providers/scaleway/scaleway/2.2.0/docs/resources/k8s_cluster) | resource |
+| [scaleway_k8s_pool.this](https://registry.terraform.io/providers/scaleway/scaleway/2.2.0/docs/resources/k8s_pool) | resource |
 
 ## Inputs
 

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,8 +4,8 @@ terraform {
 
   required_providers {
     scaleway = {
-      source  = "particuleio/scaleway"
-      version = "2.2.0-rc.0"
+      source  = "scaleway/scaleway"
+      version = "2.2.0"
     }
   }
   required_version = ">= 0.14"

--- a/versions.tf
+++ b/versions.tf
@@ -4,8 +4,8 @@ terraform {
 
   required_providers {
     scaleway = {
-      source  = "particuleio/scaleway"
-      version = "2.2.0-rc.0"
+      source  = "scaleway/scaleway"
+      version = "2.2.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
Complete plan:
```console
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.kapsule.random_pet.this["tkap"] will be created
  + resource "random_pet" "this" {
      + id        = (known after apply)
      + keepers   = {
          + "container_runtime" = "containerd"
          + "node_type"         = "GP1-XS"
        }
      + length    = 2
      + separator = "-"
    }

  # module.kapsule.scaleway_k8s_cluster.this will be created
  + resource "scaleway_k8s_cluster" "this" {
      + admission_plugins           = []
      + apiserver_cert_sans         = []
      + apiserver_url               = (known after apply)
      + cni                         = "cilium"
      + created_at                  = (known after apply)
      + delete_additional_resources = false
      + description                 = "tkap"
      + feature_gates               = []
      + id                          = (known after apply)
      + kubeconfig                  = (known after apply)
      + name                        = "tkap"
      + organization_id             = (known after apply)
      + project_id                  = (known after apply)
      + region                      = (known after apply)
      + status                      = (known after apply)
      + tags                        = []
      + type                        = "kapsule"
      + updated_at                  = (known after apply)
      + upgrade_available           = (known after apply)
      + version                     = "1.23.0"
      + wildcard_dns                = (known after apply)

      + auto_upgrade {
          + enable                        = (known after apply)
          + maintenance_window_day        = (known after apply)
          + maintenance_window_start_hour = (known after apply)
        }

      + autoscaler_config {
          + balance_similar_node_groups      = (known after apply)
          + disable_scale_down               = (known after apply)
          + estimator                        = (known after apply)
          + expander                         = (known after apply)
          + expendable_pods_priority_cutoff  = (known after apply)
          + ignore_daemonsets_utilization    = (known after apply)
          + max_graceful_termination_sec     = (known after apply)
          + scale_down_delay_after_add       = (known after apply)
          + scale_down_unneeded_time         = (known after apply)
          + scale_down_utilization_threshold = (known after apply)
        }

      + open_id_connect_config {
          + client_id       = (known after apply)
          + groups_claim    = (known after apply)
          + groups_prefix   = (known after apply)
          + issuer_url      = (known after apply)
          + required_claim  = (known after apply)
          + username_claim  = (known after apply)
          + username_prefix = (known after apply)
        }
    }

  # module.kapsule.scaleway_k8s_pool.this["tkap"] will be created
  + resource "scaleway_k8s_pool" "this" {
      + autohealing         = true
      + autoscaling         = true
      + cluster_id          = (known after apply)
      + container_runtime   = "containerd"
      + created_at          = (known after apply)
      + current_size        = (known after apply)
      + id                  = (known after apply)
      + max_size            = 3
      + min_size            = 1
      + name                = (known after apply)
      + node_type           = "GP1-XS"
      + nodes               = (known after apply)
      + region              = (known after apply)
      + size                = 2
      + status              = (known after apply)
      + tags                = []
      + updated_at          = (known after apply)
      + version             = (known after apply)
      + wait_for_pool_ready = true
      + zone                = (known after apply)

      + upgrade_policy {
          + max_surge       = 0
          + max_unavailable = 1
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
╷
│ Warning: Experimental feature "module_variable_optional_attrs" is active
│ 
│   on versions.tf line 3, in terraform:
│    3:   experiments = [module_variable_optional_attrs]
│ 
│ Experimental features are subject to breaking changes in future minor or patch releases, based on feedback.
│ 
│ If you have feedback on the design of this feature, please open a GitHub issue to discuss it.
│ 
│ (and one more similar warning elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.kapsule.random_pet.this["tkap"]: Creating...
module.kapsule.scaleway_k8s_cluster.this: Creating...
module.kapsule.random_pet.this["tkap"]: Creation complete after 0s [id=singular-mullet]
module.kapsule.scaleway_k8s_cluster.this: Creation complete after 6s [id=fr-par/5bb50180-45ad-4a2a-bd5f-7f5b79cb678d]
module.kapsule.scaleway_k8s_pool.this["tkap"]: Creating...
module.kapsule.scaleway_k8s_pool.this["tkap"]: Still creating... [10s elapsed]
...
module.kapsule.scaleway_k8s_pool.this["tkap"]: Still creating... [4m40s elapsed]
module.kapsule.scaleway_k8s_pool.this["tkap"]: Creation complete after 4m45s [id=fr-par/9f2802bb-1ebc-45fb-9ddf-2005606036ca]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

Creation and destruction works fine using the `scaleway/scaleway` provider with version `2.2.0`.