### PR TITLE
fix(autoscaler): remove deprecated optional attribut

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
 | <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | 2.2.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | 2.2.0 |
 
 ## Providers

--- a/variables.tf
+++ b/variables.tf
@@ -44,16 +44,16 @@ variable "cluster_tags" {
 variable "autoscaler_config" {
   default = []
   type = list(object({
-    disable_scale_down               = optional(bool)
-    scale_down_delay_after_add       = optional(string)
-    scale_down_unneeded_time         = optional(string)
-    estimator                        = optional(string)
-    expander                         = optional(string)
-    ignore_daemonsets_utilization    = optional(bool)
-    balance_similar_node_groups      = optional(bool)
-    expendable_pods_priority_cutoff  = optional(number)
-    scale_down_utilization_threshold = optional(number)
-    max_graceful_termination_sec     = optional(number)
+    disable_scale_down               = bool
+    scale_down_delay_after_add       = string
+    scale_down_unneeded_time         = string
+    estimator                        = string
+    expander                         = string
+    ignore_daemonsets_utilization    = bool
+    balance_similar_node_groups      = bool
+    expendable_pods_priority_cutoff  = number
+    scale_down_utilization_threshold = number
+    max_graceful_termination_sec     = number
   }))
   description = "The configuration options for the Kubernetes cluster autoscaler"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,11 +73,11 @@ variable "open_id_connect_config" {
   type = list(object({
     issuer_url      = string
     client_id       = string
-    username_claim  = optional(string)
-    username_prefix = optional(string)
-    groups_claim    = optional(list(string))
-    groups_prefix   = optional(string)
-    required_claim  = optional(list(string))
+    username_claim  = string
+    username_prefix = string
+    groups_claim    = list(string)
+    groups_prefix   = string
+    required_claim  = list(string)
   }))
   description = "The OpenID Connect configuration of the cluster"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,10 @@
 terraform {
 
-  experiments = [module_variable_optional_attrs]
-
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
       version = "2.2.0"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.3"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,5 @@ terraform {
       version = "2.2.0"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 0.14"
 }


### PR DESCRIPTION
note: it has been tested on the current terraform version (1.3.1).

if autoscaler_config is provided as input then all attributs of the object should be present

#23 