### PR TITLE
chore(kubeconfig): add dependency on nodepool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4 |
 | <a name="requirement_scaleway"></a> [scaleway](#requirement\_scaleway) | ~> 2.4 |
 
@@ -18,8 +19,9 @@ A terraform module to create a managed Kubernetes cluster on Scaleway Element.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4 |
-| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | ~> 2.4 |
+| <a name="provider_scaleway"></a> [scaleway](#provider\_scaleway) | ~> 2.25 |
 
 ## Modules
 

--- a/node-pools.tf
+++ b/node-pools.tf
@@ -35,3 +35,12 @@ resource "random_pet" "this" {
     node_type          = try(each.value.node_type, null)
   }
 }
+
+resource "null_resource" "kubeconfig" {
+  depends_on = [scaleway_k8s_pool.this]
+  triggers = {
+    host                   = scaleway_k8s_cluster.this.kubeconfig[0].host
+    token                  = scaleway_k8s_cluster.this.kubeconfig[0].token
+    cluster_ca_certificate = scaleway_k8s_cluster.this.kubeconfig[0].cluster_ca_certificate
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,11 @@ output "wildcard_dns" {
 }
 
 output "kubeconfig" {
-  value       = scaleway_k8s_cluster.this.kubeconfig
+  value = {
+    host                   = null_resource.kubeconfig.triggers.host
+    token                  = null_resource.kubeconfig.triggers.token
+    cluster_ca_certificate = base64decode(null_resource.kubeconfig.triggers.cluster_ca_certificate)
+  }
   description = "The Kubernetes configuration."
   sensitive   = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,15 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = "~> 2.4"
+      version = "~> 2.25"
     }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.4"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1"
     }
   }
   required_version = "~> 1.3"


### PR DESCRIPTION
as explain in the scaleway_k8s_cluster documentation: The null_resource is needed because when the cluster is created, it's status is pool_required, but the kubeconfig can already be downloaded. It leads the kubernetes provider to start creating its objects, but the DNS entry for the Kubernetes master is not yet ready, that's why it's needed to wait for at least a pool.