### PR TITLE
fix: wrong variable type for maintenance window day

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "auto_upgrade" {
   type = object({
     enable                        = optional(bool, false)
     maintenance_window_start_hour = optional(number)
-    maintenance_window_day        = optional(number)
+    maintenance_window_day        = optional(string)
   })
   description = "The auto upgrade configuration"
 }


### PR DESCRIPTION
Hello, 

Small PR : the maintenance_window_day is typed as a number, a string is expected.